### PR TITLE
updated readme to correct use for audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,19 +42,19 @@ const system = require('system-control')();
 // `setSystemVolume`, `isMuted`, `mute`. But, they will be executed
 // asynchronously and not serially.
 
-system.display.getSystemVolume().then(function(volume) {
+system.audio.getSystemVolume().then(function(volume) {
   // here comes your code
 });
 
-system.display.setSystemVolume(volume).then(function() {
+system.audio.setSystemVolume(volume).then(function() {
   // here comes your code
 });
 
-system.display.isMuted().then(function(muted) {
+system.audio.isMuted().then(function(muted) {
   // here comes your code
 });
 
-system.display.mute(mute).then(function() {
+system.audio.mute(mute).then(function() {
   // here comes your code
 });
 ```


### PR DESCRIPTION
edited the documentation to work with audio. I imagine you copy and pasted the "display" part accidentally. I just replaced "display" in the volume control portion of the docs with "audio"