### PR TITLE
Resolve npm peer dependency resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "mocha": "^3.2.0"
   },
   "peerDependencies": {
-    "win-audio": "^1.2.0",
+    "win-audio": "^2.0.2",
     "loudness": "git+https://github.com/RyanAfrish7/node-loudness.git"
   },
   "dependencies": {


### PR DESCRIPTION
`win-audio` does not have any breaking changes for `system-control` from what I can tell, so we should be able to just update the peerDependencies allowing v2 resolution to prevent this error:

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR!
npm ERR! While resolving: system-control@0.1.1
npm ERR! Found: win-audio@2.0.2
npm ERR! node_modules/win-audio
npm ERR!   win-audio@"^2.0.2" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer win-audio@"^1.2.0" from system-control@0.1.1
npm ERR! node_modules/system-control
npm ERR!   system-control@"^0.1.1" from the root project
npm ERR!
npm ERR! Conflicting peer dependency: win-audio@1.2.0
npm ERR! node_modules/win-audio
npm ERR!   peer win-audio@"^1.2.0" from system-control@0.1.1
npm ERR!   node_modules/system-control
npm ERR!     system-control@"^0.1.1" from the root project                                                                                                                                   npm ERR!                                                                                                                                                                                     npm ERR! Fix the upstream dependency conflict, or retry                                                                                                                                      npm ERR! this command with --force or --legacy-peer-deps                                                                                                                                     
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```